### PR TITLE
Update Alpine container entrypoint to use OpenRC

### DIFF
--- a/container_ctrl.sh
+++ b/container_ctrl.sh
@@ -31,7 +31,7 @@ ruristart() {
             START_SERVICES="service ssh start"
             ;;
         alpine)
-            START_SERVICES="openrc"
+            START_SERVICES="rm -rf /run/openrc/started/* |true && openrc"
             ;;
         *)
             START_SERVICES=""

--- a/container_ctrl.sh
+++ b/container_ctrl.sh
@@ -43,7 +43,7 @@ ruristart() {
         mount -o remount,suid $CONTAINER_DIR
     fi
 
-    ARGS="-w -p -S"
+    ARGS="-w"
 
     if [ -n "$MOUNT_POINT" ] && [ -n "$MOUNT_ENTRANCE" ]; then
         if [ "$MOUNT_READ_ONLY" = "true" ]; then

--- a/container_ctrl.sh
+++ b/container_ctrl.sh
@@ -31,7 +31,7 @@ ruristart() {
             START_SERVICES="service ssh start"
             ;;
         alpine)
-            START_SERVICES="rc-service sshd restart"
+            START_SERVICES="openrc"
             ;;
         *)
             START_SERVICES=""
@@ -43,7 +43,7 @@ ruristart() {
         mount -o remount,suid $CONTAINER_DIR
     fi
 
-    ARGS="-w"
+    ARGS="-w -p -S"
 
     if [ -n "$MOUNT_POINT" ] && [ -n "$MOUNT_ENTRANCE" ]; then
         if [ "$MOUNT_READ_ONLY" = "true" ]; then


### PR DESCRIPTION
1.  Switch Alpine container startup to OpenRC so services managed via rc-update start automatically.
2.  Set default ARGS to -s -P to fix SSH PTY errors.