### PR TITLE
Add log output and optimize openrc init.

### DIFF
--- a/container_ctrl.sh
+++ b/container_ctrl.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-
-. "${0%/*}/config.conf"
-
+HERE=${0%/*}
+. "$HERE/config.conf"
+exec > "$HERE/run.log" 2>&1
 if [ ! -e "$CONTAINER_DIR/etc/os-release" ]; then
     exit 1
 fi
@@ -31,7 +31,7 @@ ruristart() {
             START_SERVICES="service ssh start"
             ;;
         alpine)
-            START_SERVICES="rm -rf /run/openrc/started/* |true && openrc"
+            START_SERVICES="openrc sysinit"
             ;;
         *)
             START_SERVICES=""

--- a/container_ctrl.sh
+++ b/container_ctrl.sh
@@ -31,7 +31,7 @@ ruristart() {
             START_SERVICES="service ssh start"
             ;;
         alpine)
-            START_SERVICES="openrc"
+            START_SERVICES="rm -rf /run/openrc/started/* |true && openrc"
             ;;
         *)
             START_SERVICES=""

--- a/container_ctrl.sh
+++ b/container_ctrl.sh
@@ -43,7 +43,7 @@ ruristart() {
         mount -o remount,suid $CONTAINER_DIR
     fi
 
-    ARGS="-w -p -S"
+    ARGS="-w"
 
     if [ -n "$MOUNT_POINT" ] && [ -n "$MOUNT_ENTRANCE" ]; then
         if [ "$MOUNT_READ_ONLY" = "true" ]; then

--- a/container_ctrl.sh
+++ b/container_ctrl.sh
@@ -31,7 +31,7 @@ ruristart() {
             START_SERVICES="service ssh start"
             ;;
         alpine)
-            START_SERVICES="rc-service sshd restart"
+            START_SERVICES="openrc"
             ;;
         *)
             START_SERVICES=""
@@ -43,7 +43,7 @@ ruristart() {
         mount -o remount,suid $CONTAINER_DIR
     fi
 
-    ARGS="-w"
+    ARGS="-w -p -S"
 
     if [ -n "$MOUNT_POINT" ] && [ -n "$MOUNT_ENTRANCE" ]; then
         if [ "$MOUNT_READ_ONLY" = "true" ]; then


### PR DESCRIPTION
1. Add log output to run.log.

2. Start OpenRC with the sysinit parameter to resolve startup failures of services that depend on "localmount".